### PR TITLE
Fixing typo in whitepaper URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Storj white paper v3
 
-Available at [https://storj.io/white-paper](https://storj.io/white-paper)
+Available at [https://storj.io/whitepaper](https://storj.io/whitepaper)


### PR DESCRIPTION
URL of whitepaper seems to be changed from https://www.storj.io/white-paper to https://www.storj.io/whitepaper. 

Similar to storj/storj#0084164f3, the URL can be changed here.